### PR TITLE
Global Types, Member schema, and MenuItem

### DIFF
--- a/app/api/members/[id]/route.tsx
+++ b/app/api/members/[id]/route.tsx
@@ -2,15 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/prisma/client';
 import { partialMemberSchema } from '../schema';
 
-type IdParam = {
-  params: {
-    id: string;
-  }
-}
-
 export async function GET(
   request: NextRequest,
-  { params }: IdParam) {
+  { params }: ReqParams) {
     const member = await prisma.member.findUnique({
       where: {
         id: parseInt(params.id)
@@ -22,7 +16,7 @@ export async function GET(
 
 export async function PATCH(
   request: NextRequest,
-  { params }: IdParam) {
+  { params }: ReqParams) {
     const body = await request.json();
     const validation = partialMemberSchema.safeParse(body);
     if (!validation.success) return NextResponse.json(validation.error.errors, { status: 404 });
@@ -40,7 +34,7 @@ export async function PATCH(
 
 export async function DELETE(
   request: NextRequest,
-  { params }: IdParam) {
+  { params }: ReqParams) {
     const deletedMember = await prisma.member.delete({
       where: {
         id: parseInt(params.id)

--- a/app/api/members/route.tsx
+++ b/app/api/members/route.tsx
@@ -17,7 +17,5 @@ export async function POST(request: NextRequest) {
       ...body
     }
   });
-  return NextResponse.json(
-    member, 
-    { status: 201 });
+  return NextResponse.json(member, { status: 201 });
 }

--- a/app/api/menuitems/route.tsx
+++ b/app/api/menuitems/route.tsx
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/prisma/client';
+import { menuItemSchema } from './schema';
 
 export async function GET(request: NextRequest) {
   const menuItems = await prisma.menuItem.findMany();
@@ -9,4 +10,12 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   const body = await request.json();
+  const validation = menuItemSchema.safeParse(body);
+  if (!validation.success) return NextResponse.json(validation.error.errors, { status: 404 });
+  const menuItem = await prisma.menuItem.create({
+    data: {
+      ...body
+    }
+  });
+  return NextResponse.json(menuItem, { status: 200 });
 }

--- a/app/api/menuitems/route.tsx
+++ b/app/api/menuitems/route.tsx
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/prisma/client';
+
+export async function GET(request: NextRequest) {
+  const menuItems = await prisma.menuItem.findMany();
+  if (!menuItems) return NextResponse.json({ error: 'No menu items found' }, { status: 404 });
+  return NextResponse.json(menuItems, { status: 200 });
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+}

--- a/app/api/menuitems/schema.ts
+++ b/app/api/menuitems/schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const menuItemSchema = z.object({
+  name: z.string().min(1),
+  price: z.number(),
+  ingredients: z.array(z.string()),
+  allergies: z.array(z.string()),
+  img: z.string()
+}).strict();

--- a/app/types/global.d.ts
+++ b/app/types/global.d.ts
@@ -1,0 +1,9 @@
+export {}
+
+declare global {
+  type ReqParams = {
+    params: {
+      id: string;
+    }
+  }
+}

--- a/prisma/migrations/20240329183630_on_member_name_is_no_longer_optional/migration.sql
+++ b/prisma/migrations/20240329183630_on_member_name_is_no_longer_optional/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `name` on table `Member` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "Member" ALTER COLUMN "name" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,7 +20,7 @@ model Member {
   password    String
   profilePic  String?
   quizzes     Grade[]
-  teams       Team[]
+  teams       Team[] // change to one - many
   isAdmin     Boolean @default(false)
 }
 
@@ -35,6 +35,7 @@ model Quiz {
   name      String     @unique
   members   Grade[]
   questions Question[]
+  // team
 }
 
 model Grade {
@@ -63,4 +64,5 @@ model MenuItem {
   ingredients String[] @default([])
   allergies   String[] @default([])
   img         String?
+  // team
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,7 @@ datasource db {
 model Member {
   id          Int     @id @default(autoincrement())
   email       String  @unique
-  name        String?
+  name        String
   password    String
   profilePic  String?
   quizzes     Grade[]


### PR DESCRIPTION
#Global Types
Now in `~/app/types/global.d.ts` types can be stored and automatically exported throughout the app.
The initial type stored right now, `ReqParams` is used for submitted id parameters to endpoint functions.
Any other types that you reuse (or that you simply want to store here) can be added anywhere within the 
`declare global {}` brackets.

## Member Schema
Changed `name` property from optional to required for new member creation.

## Menu Item
Starting to build out schema and endpoints for `menuItem`. Started with GET and POST routes for `/menuitems`.