### PR TITLE
Global types export

### DIFF
--- a/app/api/members/[id]/route.tsx
+++ b/app/api/members/[id]/route.tsx
@@ -2,15 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/prisma/client';
 import { partialMemberSchema } from '../schema';
 
-type IdParam = {
-  params: {
-    id: string;
-  }
-}
-
 export async function GET(
   request: NextRequest,
-  { params }: IdParam) {
+  { params }: ReqParams) {
     const member = await prisma.member.findUnique({
       where: {
         id: parseInt(params.id)
@@ -22,7 +16,7 @@ export async function GET(
 
 export async function PATCH(
   request: NextRequest,
-  { params }: IdParam) {
+  { params }: ReqParams) {
     const body = await request.json();
     const validation = partialMemberSchema.safeParse(body);
     if (!validation.success) return NextResponse.json(validation.error.errors, { status: 404 });
@@ -40,7 +34,7 @@ export async function PATCH(
 
 export async function DELETE(
   request: NextRequest,
-  { params }: IdParam) {
+  { params }: ReqParams) {
     const deletedMember = await prisma.member.delete({
       where: {
         id: parseInt(params.id)

--- a/app/types/global.d.ts
+++ b/app/types/global.d.ts
@@ -1,0 +1,9 @@
+export {}
+
+declare global {
+  type ReqParams = {
+    params: {
+      id: string;
+    }
+  }
+}


### PR DESCRIPTION
# Global Types
Now in `~/app/types/global.d.ts` types can be stored and automatically exported throughout the app. 
The initial type stored right now, `ReqParams` is used for submitted id parameters to endpoint functions. 
Any other types that you reuse (or that you simply want to store here) can be added anywhere within the `declare global {}` brackets.