### PR TITLE
/grades endpoint

### DIFF
--- a/app/api/grades/route.tsx
+++ b/app/api/grades/route.tsx
@@ -4,5 +4,12 @@ import { gradeSchema } from './schema'
 
 export async function POST(request: NextRequest) {
   const body = await request.json();
-
+  const validation = gradeSchema.safeParse(body);
+  if (!validation.success) return NextResponse.json(validation.error.errors, { status: 404 });
+  const grade = await prisma.grade.create({
+    data: {
+      ...body
+    }
+  });
+  return NextResponse.json(grade, { status: 200 });
 }

--- a/app/api/grades/route.tsx
+++ b/app/api/grades/route.tsx
@@ -1,0 +1,8 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/prisma/client';
+import { gradeSchema } from './schema'
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+
+}

--- a/app/api/grades/route.tsx
+++ b/app/api/grades/route.tsx
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/prisma/client';
-import { gradeSchema } from './schema'
+import { gradeSchema, extendedGradeSchema } from './schema';
 
 export async function POST(request: NextRequest) {
   const body = await request.json();
@@ -12,4 +12,20 @@ export async function POST(request: NextRequest) {
     }
   });
   return NextResponse.json(grade, { status: 200 });
+}
+
+export async function PATCH(request: NextRequest) {
+  const body = await request.json();
+  const validation = extendedGradeSchema.safeParse(body);
+  if (!validation.success) return NextResponse.json(validation.error.errors, { status: 404 });
+  const updatedGrade = await prisma.grade.update({
+    where: { 
+      gradeId: { 
+        quizId: body.quizId ,
+        memberId: body.memberId
+      } 
+    },
+    data: { grade: body.grade }
+  });
+  return NextResponse.json(updatedGrade, { status: 200 });
 }

--- a/app/api/grades/schema.ts
+++ b/app/api/grades/schema.ts
@@ -5,6 +5,6 @@ export const gradeSchema = z.object({
   quizId: z.number()
 }).strict();
 
-export const partialGradeSchema = z.object({
+export const extendedGradeSchema = gradeSchema.extend({
   grade: z.number()
-}).partial().strict();
+}).strict();

--- a/app/api/grades/schema.ts
+++ b/app/api/grades/schema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const gradeSchema = z.object({
+  grade: z.number(),
+  memberId: z.number(),
+  quizId: z.number()
+}).strict();

--- a/app/api/grades/schema.ts
+++ b/app/api/grades/schema.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod';
 
 export const gradeSchema = z.object({
-  grade: z.number(),
   memberId: z.number(),
   quizId: z.number()
 }).strict();
+
+export const partialGradeSchema = z.object({
+  grade: z.number()
+}).partial().strict();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,7 +49,7 @@ model Grade {
   memberId Int
   grade    Int?
 
-  @@id([quizId, memberId])
+  @@id(name: "gradeId", [quizId, memberId])
 }
 
 model Question {


### PR DESCRIPTION
## Grades

### Schema
Created a `gradeSchema` that takes in `quizId` and `memberId`. The idea is that when a member is assigned a quiz, a row is created between the two on the `Grade` table that has both id's and a null default value for the grade parameter. 
The `extendedGradeSchema` will exist to update rows on the `Grade` table.

### /grades PATCH
Since the `Grade` table is populated by rows that contain `memberId`, `quizId`, and `grade`, I figured we could keep the  `PATCH` route simple by not creating a separate `/grades/:id/:id` endpoint. Instead, we'll use the `/grades` endpoint and pass the `memberId` and `quizId` in the body along with the `grade` value to update the row.

### /grades POST
Pretty simple, when a quiz is assigned to a member, we create a `Grade` table entry by passing `memberId` and `quizId` in the `POST` request to `/grades`.

### /grades GET
I don't have an endpoint for this yet. I'm not sure where this would go actually. We'll need to discuss but I think we might actually have `GET` calls for grades in the `/members/:id` and `/quizzes/:id` routes. We'll discuss!

###  schema.prisma
Made a small change to the `Grade` model so that it's unique id (`@@id([quizId, memberId])`) will just be named `gradeId`. Makes it easier to query in the endpoints.